### PR TITLE
feat: Make Vendor column required and remove vendor_mapping dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 python outsourcing_qc_system.py <input_path>
 ```
-The system processes Excel files containing tool management data with required columns: Tool_Number, Tool Column, Customer schedule, Responsible User.
+The system processes Excel files containing tool management data with required columns: Tool_Number, Tool Column, Customer schedule, Responsible User, Vendor.
 
 ### Testing
 ```bash

--- a/outsourcing_qc_check_points.py
+++ b/outsourcing_qc_check_points.py
@@ -4,15 +4,14 @@ from pathlib import Path
 from checkpoint_strategies import CheckpointRegistry, PackageReadinessCheckpoint, FinalReportCheckpoint
 
 class OutsourcingQcCheckPoints:
-    def __init__(self, df, vendor_mapping=None):
+    def __init__(self, df):
         self.df = df
         self.today = datetime.now()
-        self.vendor_mapping = vendor_mapping or {}
         
         # Initialize the checkpoint registry with default checkpoints
         CheckpointRegistry.clear()
         CheckpointRegistry.register(PackageReadinessCheckpoint())
-        CheckpointRegistry.register(FinalReportCheckpoint(vendor_mapping))
+        CheckpointRegistry.register(FinalReportCheckpoint())
 
     def get_failures(self):
         """

--- a/outsourcing_qc_extractor.py
+++ b/outsourcing_qc_extractor.py
@@ -5,9 +5,10 @@ class OutsourcingQcExtractor:
         self.input_path = input_path
         self.required_columns = [
             'Tool_Number',
-            'Tool Column',
+            'Tool Column', 
             'Customer schedule',
-            'Responsible User'
+            'Responsible User',
+            'Vendor'
         ]
 
     def get_raw_data(self):

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -21,7 +21,8 @@ class TestOutsourcingQcCheckPoints(unittest.TestCase):
             'Project Start Date': [
                 self.today - timedelta(days=5),
                 self.today - timedelta(days=1)
-            ]
+            ],
+            'Vendor': ['vendor_a', 'vendor_b']
         }
         self.df = pd.DataFrame(data)
 
@@ -52,6 +53,67 @@ class TestOutsourcingQcCheckPoints(unittest.TestCase):
         self.assertEqual(failures['Package Readiness'][0]['Tool_Number'], 'T001')
         self.assertEqual(len(failures['Final Report']), 1)
         self.assertEqual(failures['Final Report'][0]['Tool_Number'], 'T001')
+
+    def test_vendor_column_usage(self):
+        """Test that vendor column from each row is used for final report checking"""
+        today = datetime.now()
+        data = {
+            'Tool_Number': ['T001', 'T002'],
+            'Tool Column': ['ProjectA', 'ProjectB'],
+            'Customer schedule': [
+                today + timedelta(days=3),  # Both within 7 days for final report check
+                today + timedelta(days=3)
+            ],
+            'Project Start Date': [
+                today - timedelta(weeks=3),
+                today - timedelta(weeks=3)
+            ],
+            'Responsible User': ['user1@test.com', 'user2@test.com'],
+            'Vendor': ['vendor_a', 'vendor_b']  # Different vendors per row
+        }
+        df = pd.DataFrame(data)
+        
+        with patch('pathlib.Path.glob') as mock_glob:
+            # Mock different vendor file patterns
+            def glob_side_effect(pattern):
+                if 'vendor_a' in str(pattern) or 'Report_T001_' in pattern:
+                    return []  # Vendor A Excel files not found
+                if 'vendor_b' in str(pattern) or 'VendorB' in str(pattern):
+                    return []  # Vendor B files not found
+                return []
+            
+            mock_glob.side_effect = glob_side_effect
+            
+            checker = OutsourcingQcCheckPoints(df)
+            failures = checker.get_failures()
+            
+            # Both should fail but with different vendor-specific reasons
+            self.assertEqual(len(failures['Final Report']), 2)
+            self.assertIn('Vendor', failures['Final Report'][0])
+            self.assertIn('Vendor', failures['Final Report'][1])
+
+    def test_unsupported_vendor_fails_fast(self):
+        """Test that unsupported vendors fail immediately without file checking"""
+        today = datetime.now()
+        data = {
+            'Tool_Number': ['T001'],
+            'Tool Column': ['ProjectA'],
+            'Customer schedule': [today + timedelta(days=3)],
+            'Project Start Date': [today - timedelta(weeks=3)],
+            'Responsible User': ['user1@test.com'],
+            'Vendor': ['unsupported_vendor']  # This vendor doesn't exist in VendorRuleRegistry
+        }
+        df = pd.DataFrame(data)
+        
+        checker = OutsourcingQcCheckPoints(df)
+        failures = checker.get_failures()
+        
+        # Should fail with unsupported vendor message
+        self.assertEqual(len(failures['Final Report']), 1)
+        failure = failures['Final Report'][0]
+        self.assertEqual(failure['Tool_Number'], 'T001')
+        self.assertEqual(failure['Vendor'], 'unsupported_vendor')
+        self.assertIn('Unsupported vendor', failure['Fail Reason'])
 
 
 if __name__ == '__main__':

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -12,7 +12,8 @@ class TestOutsourcingQcExtractor(unittest.TestCase):
             'Tool_Number': ['T001'],
             'Tool Column': ['ProjectA'],
             'Customer schedule': ['2025-07-15'],
-            'Responsible User': ['test@example.com']
+            'Responsible User': ['test@example.com'],
+            'Vendor': ['vendor_a']
         }
         df = pd.DataFrame(data)
         df.to_excel(self.test_file, index=False)

--- a/tests/test_refactored_checkpoints.py
+++ b/tests/test_refactored_checkpoints.py
@@ -20,7 +20,8 @@ class TestRefactoredCheckpoints(unittest.TestCase):
                 today - timedelta(weeks=3),
                 today - timedelta(weeks=2)
             ],
-            'Responsible User': ['user1@test.com', 'user2@test.com']
+            'Responsible User': ['user1@test.com', 'user2@test.com'],
+            'Vendor': ['vendor_a', 'vendor_b']
         }
         self.df = pd.DataFrame(self.test_data)
 
@@ -94,10 +95,9 @@ class TestRefactoredCheckpoints(unittest.TestCase):
         for checkpoint_name in expected_checkpoints:
             self.assertIn(checkpoint_name, failures)
 
-    def test_vendor_mapping_still_works(self):
-        """Test that vendor mapping functionality is preserved."""
-        vendor_mapping = {'ProjectA': 'vendor_a', 'ProjectB': 'vendor_b'}
-        checker = OutsourcingQcCheckPoints(self.df, vendor_mapping)
+    def test_vendor_column_functionality_works(self):
+        """Test that vendor column functionality works correctly."""
+        checker = OutsourcingQcCheckPoints(self.df)
         
         failures = checker.get_failures()
         

--- a/tests/test_vendor_rules.py
+++ b/tests/test_vendor_rules.py
@@ -33,7 +33,7 @@ class TestVendorRules(unittest.TestCase):
         rule = VendorRuleRegistry.get_rule('custom')
         self.assertEqual(rule.get_fail_reason(), "Custom vendor rule failed")
 
-    def test_check_points_with_vendor_mapping(self):
+    def test_check_points_with_vendor_column(self):
         today = datetime.now()
         data = {
             'Tool_Number': ['T001', 'T002'],
@@ -46,16 +46,12 @@ class TestVendorRules(unittest.TestCase):
                 today - timedelta(weeks=3),
                 today - timedelta(weeks=3)
             ],
-            'Responsible User': ['user1@test.com', 'user2@test.com']
+            'Responsible User': ['user1@test.com', 'user2@test.com'],
+            'Vendor': ['vendor_a', 'vendor_b']  # Vendor info now directly in data
         }
         df = pd.DataFrame(data)
         
-        vendor_mapping = {
-            'ProjectA': 'vendor_a',
-            'ProjectB': 'vendor_b'
-        }
-        
-        checker = OutsourcingQcCheckPoints(df, vendor_mapping)
+        checker = OutsourcingQcCheckPoints(df)
         failures = checker.get_failures()
         
         self.assertIn('Final Report', failures)


### PR DESCRIPTION
## Summary
This PR implements a significant simplification of the vendor handling system by making `Vendor` a required column in the input data and removing the `vendor_mapping` dependency entirely.

## Key Changes

### 🔧 **Core Logic Improvements**
- **Fixed pandas Series access bug**: Changed `hasattr(row, 'Vendor')` to `'Vendor' in row and pd.notna(row['Vendor'])`
- **Direct vendor mapping**: Each row's `Vendor` column value now maps directly to `VendorRuleRegistry` rules
- **Fail-fast validation**: Unsupported vendors immediately return failure without attempting file checks

### 🧹 **API Simplification** 
- Removed `vendor_mapping` parameter from:
  - `FinalReportCheckpoint()` constructor
  - `OutsourcingQcCheckPoints(df)` constructor  
  - `CheckpointRegistry.initialize_defaults()` method

### 📋 **Required Column Addition**
- Added `Vendor` as 5th required column alongside:
  - `Tool_Number`
  - `Tool Column` 
  - `Customer schedule`
  - `Responsible User`

### 🚨 **Enhanced Error Handling**
- **Unsupported vendor**: Returns `"Unsupported vendor or missing vendor information"`
- **Missing vendor**: Validated at extraction layer as required field
- **Clear identification**: Vendor name included in all failure reports

## Technical Benefits

### 🎯 **Follows Linus Torvalds Principles**
- **"Good Taste"**: Eliminated unnecessary fallback logic branches
- **"Fail Fast"**: Unsupported vendors immediately return errors
- **"Simplicity"**: Removed intermediate mapping layer complexity

### 📊 **Data Flow Simplification**
```
Before: Excel → Vendor column → vendor_mapping lookup → VendorRuleRegistry → Rules
After:  Excel → Vendor column → VendorRuleRegistry → Rules
```

### 🧪 **Comprehensive Testing**
- ✅ **28/28 tests pass**
- ✅ Added `test_unsupported_vendor_fails_fast()`  
- ✅ Added `test_vendor_column_usage()`
- ✅ Updated all existing tests with `Vendor` column
- ✅ Verified backward compatibility scenarios

## Breaking Changes
⚠️ **Input Data Requirements**
- `Vendor` column is now required in all input Excel files
- Files without `Vendor` column will fail validation

⚠️ **API Changes**  
- `FinalReportCheckpoint(vendor_mapping=...)` → `FinalReportCheckpoint()`
- `OutsourcingQcCheckPoints(df, vendor_mapping=...)` → `OutsourcingQcCheckPoints(df)`

## Migration Guide
1. **Add `Vendor` column** to all input Excel files
2. **Remove `vendor_mapping` parameters** from checkpoint initialization
3. **Update vendor values** to match keys in `VendorRuleRegistry._rules`:
   - `'vendor_a'`, `'vendor_b'`, `'vendor_c'`, `'default'`

## Test Results
```bash
Ran 28 tests in 0.570s
OK
```

🤖 Generated with [Claude Code](https://claude.ai/code)